### PR TITLE
Deterministic import order

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>none</org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>4</org-netbeans-modules-editor-indent.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
+        <org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.CodeStyle.usedProfile>project</org-netbeans-modules-editor-indent.CodeStyle.usedProfile>
+    </properties>
+</project-shared-configuration>

--- a/src/main/java/org/corpus_tools/peppermodules/mergingModules/Merger.java
+++ b/src/main/java/org/corpus_tools/peppermodules/mergingModules/Merger.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,7 +107,7 @@ public class Merger extends PepperManipulatorImpl implements PepperManipulator {
 		private Map<String, List<SNode>> map = null;
 
 		public Multimap() {
-			map = new HashMap<>();
+			map = new LinkedHashMap<>();
 		}
 
 		public void put(String sId, SNode sNode) {
@@ -192,7 +193,7 @@ public class Merger extends PepperManipulatorImpl implements PepperManipulator {
 			mappingTable = new Multimap();
 			// TODO add mapping properties to table
 			for (SCorpusGraph graph : getSaltProject().getCorpusGraphs()) {
-				if (graph.getCorpora().size() != 0) {
+				if (!graph.getCorpora().isEmpty()) {
 					for (SCorpus sCorpus : graph.getCorpora()) {
 						// TODO check if sCorpus.getId() is contained in
 						// mapping properties

--- a/src/test/java/org/corpus_tools/peppermodules/mergingModules/tests/Merger_internalTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/mergingModules/tests/Merger_internalTest.java
@@ -119,28 +119,26 @@ public class Merger_internalTest extends Merger {
 		getFixture().getSaltProject().addCorpusGraph(graph2);
 		getFixture().getSaltProject().addCorpusGraph(graph3);
 
-		
 		List<Identifier> importOrder1 = this.proposeImportOrder(graph1);
-        List<Identifier> importOrder2 = this.proposeImportOrder(graph2);
+		List<Identifier> importOrder2 = this.proposeImportOrder(graph2);
 		List<Identifier> importOrder3 = this.proposeImportOrder(graph3);
-		
-        assertNotNull(importOrder1);
+
+		assertNotNull(importOrder1);
 		assertNotNull(importOrder2);
-        assertNotNull(importOrder3);
-        
+		assertNotNull(importOrder3);
+
 		assertEquals(1, importOrder1.size());
 		assertEquals(3, importOrder2.size());
 		assertEquals(3, importOrder3.size());
-        
-        // check that there are the documents with the same ID at the same
-        // index at each import
-        
-        assertEquals(d1.getIdentifier(), importOrder1.get(0));
+
+		// check that there are the documents with the same ID at the same
+		// index at each import
+		assertEquals(d1.getIdentifier(), importOrder1.get(0));
 		assertEquals(d1_2.getIdentifier(), importOrder2.get(0));
 		assertEquals(d1_3.getIdentifier(), importOrder3.get(0));
 
 		assertEquals(d2_2.getIdentifier(), importOrder2.get(1));
-   		assertEquals(d2_3.getIdentifier(), importOrder3.get(1));
+		assertEquals(d2_3.getIdentifier(), importOrder3.get(1));
 
 		assertEquals(d3_2.getIdentifier(), importOrder2.get(2));
 		assertEquals(d3_3.getIdentifier(), importOrder3.get(2));

--- a/src/test/java/org/corpus_tools/peppermodules/mergingModules/tests/Merger_internalTest.java
+++ b/src/test/java/org/corpus_tools/peppermodules/mergingModules/tests/Merger_internalTest.java
@@ -119,24 +119,30 @@ public class Merger_internalTest extends Merger {
 		getFixture().getSaltProject().addCorpusGraph(graph2);
 		getFixture().getSaltProject().addCorpusGraph(graph3);
 
-		List<Identifier> importOrder;
+		
+		List<Identifier> importOrder1 = this.proposeImportOrder(graph1);
+        List<Identifier> importOrder2 = this.proposeImportOrder(graph2);
+		List<Identifier> importOrder3 = this.proposeImportOrder(graph3);
+		
+        assertNotNull(importOrder1);
+		assertNotNull(importOrder2);
+        assertNotNull(importOrder3);
+        
+		assertEquals(1, importOrder1.size());
+		assertEquals(3, importOrder2.size());
+		assertEquals(3, importOrder3.size());
+        
+        // check that there are the documents with the same ID at the same
+        // index at each import
+        
+        assertEquals(d1.getIdentifier(), importOrder1.get(0));
+		assertEquals(d1_2.getIdentifier(), importOrder2.get(0));
+		assertEquals(d1_3.getIdentifier(), importOrder3.get(0));
 
-		importOrder = this.proposeImportOrder(graph1);
-		assertNotNull(importOrder);
-		assertEquals(1, importOrder.size());
-		assertEquals(d1.getIdentifier(), importOrder.get(0));
+		assertEquals(d2_2.getIdentifier(), importOrder2.get(1));
+   		assertEquals(d2_3.getIdentifier(), importOrder3.get(1));
 
-		importOrder = this.proposeImportOrder(graph2);
-		assertNotNull(importOrder);
-		assertEquals(3, importOrder.size());
-		assertEquals(d1_2.getIdentifier(), importOrder.get(2));
-		assertEquals(d2_2.getIdentifier(), importOrder.get(1));
-		assertEquals(d3_2.getIdentifier(), importOrder.get(0));
-
-		importOrder = this.proposeImportOrder(graph3);
-		assertNotNull(importOrder);
-		assertEquals(d1_3.getIdentifier(), importOrder.get(2));
-		assertEquals(d2_3.getIdentifier(), importOrder.get(1));
-		assertEquals(d3_3.getIdentifier(), importOrder.get(0));
+		assertEquals(d3_2.getIdentifier(), importOrder2.get(2));
+		assertEquals(d3_3.getIdentifier(), importOrder3.get(2));
 	}
 }


### PR DESCRIPTION
I changed the createMapping() function to use a LinkedHashMap instead of a HashMap as delegate in "Multimap". Thus instead of having a more or less random order the order is now deterministic. 

The test case needed to be updated. But I'm not sure if there was in implicit semantic assumed in the test case (that was randomly working with the old implementation).