### PR TITLE
Bug fix for cases where second input has no non-terminal nodes

### DIFF
--- a/src/main/java/org/corpus_tools/peppermodules/mergingModules/MergerMapper.java
+++ b/src/main/java/org/corpus_tools/peppermodules/mergingModules/MergerMapper.java
@@ -448,7 +448,7 @@ public class MergerMapper extends PepperMapperImpl implements PepperMapper {
 	 * the nodes:
 	 * 
 	 * struct1 and span2 are returned, even if a pointing relation connects
-	 * struct1 and span2.
+	 * struct1 and span2. Note that undominated tokens are also treated as roots.
 	 * 
 	 * @return
 	 */
@@ -459,6 +459,7 @@ public class MergerMapper extends PepperMapperImpl implements PepperMapper {
 		relations.addAll((List<SRelation>) (List<? extends SRelation>) other.getSpanningRelations());
 		relations.addAll((List<SRelation>) (List<? extends SRelation>) other.getDominanceRelations());
 		Set<SNode> notRootElements = new HashSet<>();
+		retSet.addAll(other.getTokens()); // initially assume all tokens are roots, they will be removed if found to be dominated
 		for (SRelation<SNode, SNode> relation : relations) {
 			// mark destination as no root
 			if (!notRootElements.contains(relation.getTarget())) {


### PR DESCRIPTION
- Non-dominated tokens in the 'other' source were not being recognized as roots in getRoots()
- Added all tokens as potential roots, removed only if found as target of coverage or dominance relation
- Fixes korpling/pepperModules-MergingModule#10
